### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Service-Unit-469/Sendra/security/code-scanning/1](https://github.com/Service-Unit-469/Sendra/security/code-scanning/1)

To fix the problem, add a `permissions:` block to the workflow to specify the minimum required permissions for GITHUB_TOKEN. All actions in the workflow (.github/workflows/build.yml) only need to check out code and run local build and test commands, which require only read access to repository content. Therefore, it is best to add the following block at the workflow root (just below the `name:` line and before `on:`), as this will apply to all jobs unless overridden. No changes to steps, methods, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
