### PR TITLE
fix: reporting issues with overcounting deliveries and not showing events

### DIFF
--- a/packages/dashboard/src/lib/campaignStats.ts
+++ b/packages/dashboard/src/lib/campaignStats.ts
@@ -1,0 +1,13 @@
+import type { Campaign } from "@sendra/shared";
+
+type CampaignStats = NonNullable<Campaign["stats"]>;
+
+/**
+ * Open rate uses delivered count when SES has reported deliveries; otherwise falls back to sent.
+ * Result is capped at 100% so display stays sane if counters drift.
+ */
+export function campaignOpenRatePercent(stats: CampaignStats): number {
+  const denom = stats.delivered > 0 ? stats.delivered : stats.sent;
+  if (denom <= 0) return 0;
+  return Math.min(100, Math.round((stats.opened / denom) * 100));
+}

--- a/packages/dashboard/src/pages/dashboard/campaigns/View/Published.tsx
+++ b/packages/dashboard/src/pages/dashboard/campaigns/View/Published.tsx
@@ -14,6 +14,7 @@ import FullscreenLoader from "../../../../components/Utility/FullscreenLoader/Fu
 import { useCampaigns } from "../../../../lib/hooks/campaigns";
 import { useEmailsByCampaign } from "../../../../lib/hooks/emails";
 import { useCurrentProject } from "../../../../lib/hooks/projects";
+import { campaignOpenRatePercent } from "../../../../lib/campaignStats";
 import { network } from "../../../../lib/network";
 
 /**
@@ -35,15 +36,32 @@ export default function PublishedCampaign({ campaign, mutate: campaignMutate }: 
   const summaryMetrics =
     stats.total > 0
       ? ([
-          { label: "Emails Sent", value: stats.total },
-          { label: "Queued", value: Math.max(stats.total - stats.sent, 0) },
-          { label: "Open Rate", value: stats.sent > 0 ? Math.round((stats.opened / stats.sent) * 100) : 0, suffix: "%" },
+          { label: "Recipients", value: stats.total },
+          { label: "Sent", value: stats.sent },
+          { label: "Open Rate", value: campaignOpenRatePercent(stats), suffix: "%" },
         ] as const)
       : emails && emails.length > 0
         ? ([
-            { label: "Emails Sent", value: emails.length },
-            { label: "Queued", value: emails.filter((e) => e.status === "QUEUED").length },
-            { label: "Open Rate", value: Math.round((emails.filter((e) => e.status === "OPENED").length / emails.length) * 100), suffix: "%" },
+            { label: "Recipients", value: emails.length },
+            {
+              label: "Sent",
+              value: emails.filter((e) => e.status !== "QUEUED").length,
+            },
+            {
+              label: "Open Rate",
+              value: Math.min(
+                100,
+                Math.round(
+                  (emails.filter((e) => e.status === "OPENED").length /
+                    Math.max(
+                      emails.filter((e) => e.status === "DELIVERED" || e.status === "OPENED").length,
+                      1,
+                    )) *
+                    100,
+                ),
+              ),
+              suffix: "%",
+            },
           ] as const)
         : null;
 

--- a/packages/dashboard/src/pages/dashboard/campaigns/View/Published.tsx
+++ b/packages/dashboard/src/pages/dashboard/campaigns/View/Published.tsx
@@ -11,10 +11,10 @@ import ThreeColMetricsSummary from "../../../../components/Metrics/ThreeColMetri
 import { OnPageTabs } from "../../../../components/Navigation/Tabs/OnPageTabs";
 import Table from "../../../../components/Table/Table";
 import FullscreenLoader from "../../../../components/Utility/FullscreenLoader/FullscreenLoader";
+import { campaignOpenRatePercent } from "../../../../lib/campaignStats";
 import { useCampaigns } from "../../../../lib/hooks/campaigns";
 import { useEmailsByCampaign } from "../../../../lib/hooks/emails";
 import { useCurrentProject } from "../../../../lib/hooks/projects";
-import { campaignOpenRatePercent } from "../../../../lib/campaignStats";
 import { network } from "../../../../lib/network";
 
 /**
@@ -51,14 +51,7 @@ export default function PublishedCampaign({ campaign, mutate: campaignMutate }: 
               label: "Open Rate",
               value: Math.min(
                 100,
-                Math.round(
-                  (emails.filter((e) => e.status === "OPENED").length /
-                    Math.max(
-                      emails.filter((e) => e.status === "DELIVERED" || e.status === "OPENED").length,
-                      1,
-                    )) *
-                    100,
-                ),
+                Math.round((emails.filter((e) => e.status === "OPENED").length / Math.max(emails.filter((e) => e.status === "DELIVERED" || e.status === "OPENED").length, 1)) * 100),
               ),
               suffix: "%",
             },

--- a/packages/dashboard/src/pages/dashboard/campaigns/index.tsx
+++ b/packages/dashboard/src/pages/dashboard/campaigns/index.tsx
@@ -15,6 +15,7 @@ import Modal from "../../../components/Overlay/Modal/Modal";
 import Skeleton from "../../../components/Skeleton/Skeleton";
 import Empty from "../../../components/Utility/Empty/Empty";
 import FullscreenLoader from "../../../components/Utility/FullscreenLoader/FullscreenLoader";
+import { campaignOpenRatePercent } from "../../../lib/campaignStats";
 import { useCampaigns } from "../../../lib/hooks/campaigns";
 import { useCurrentProject } from "../../../lib/hooks/projects";
 import { useTemplates } from "../../../lib/hooks/templates";
@@ -143,7 +144,7 @@ export default function Index() {
               {campaigns.map((c) => {
                 const stats = c.stats ?? { total: 0, sent: 0, delivered: 0, opened: 0, errors: 0, errorDetails: [] };
                 const queued = Math.max(stats.total - stats.sent, 0);
-                const openRatePct = stats.sent > 0 ? Math.round((stats.opened / stats.sent) * 100) : 0;
+                const openRatePct = campaignOpenRatePercent(stats);
                 return (
                   <div className="col-span-1 divide-y divide-neutral-200 rounded-sm border border-neutral-200 bg-white" key={c.id}>
                     <div className="flex w-full items-center justify-between space-x-6 p-6">
@@ -171,7 +172,7 @@ export default function Index() {
                                 {stats.total > 0 && (
                                   <div>
                                     <label htmlFor="emails-in-queue" className={"text-xs font-medium text-neutral-500"}>
-                                      Emails in queue
+                                      Pending send
                                     </label>
                                     <p className="mt-1 truncate text-sm text-neutral-500" id="emails-in-queue">
                                       {queued}

--- a/packages/lib/src/persistence/BasePersistence.ts
+++ b/packages/lib/src/persistence/BasePersistence.ts
@@ -107,7 +107,7 @@ export abstract class BasePersistence<T extends BaseItem> {
   public readonly tableName: string;
 
   constructor(
-    private readonly type: string,
+    protected readonly type: string,
     private readonly schema: ZodType<T>,
   ) {
     const config = getPersistenceConfig();
@@ -275,7 +275,7 @@ export abstract class BasePersistence<T extends BaseItem> {
   }
 
   @logMethodReturningPromise("BasePersistence")
-  async findBy(params: QueryParams): Promise<QueryResult<EmbeddedObject<T>>> {
+  async findBy(params: QueryParams, opts?: { scanNewestFirst?: boolean }): Promise<QueryResult<EmbeddedObject<T>>> {
     const { key, value, comparator, limit, cursor, embed, embedLimit } = params;
 
     const indexInfo = this.getIndexInfo(key);
@@ -302,6 +302,7 @@ export abstract class BasePersistence<T extends BaseItem> {
 
       Limit: limit,
       ExclusiveStartKey: cursor ? JSON.parse(Buffer.from(cursor, "base64").toString("ascii")) : undefined,
+      ...(opts?.scanNewestFirst ? { ScanIndexForward: false } : {}),
       ReturnConsumedCapacity: "TOTAL",
     } as QueryCommandInput;
     this.logger.debug(config, "Executing query");
@@ -341,17 +342,21 @@ export abstract class BasePersistence<T extends BaseItem> {
 
   @logMethodReturningPromise("BasePersistence")
   async findAllBy(params: Omit<QueryParams, "limit" | "cursor"> & { stop?: StopFn<T> }): Promise<EmbeddedObject<T>[]> {
-    const { embed, embedLimit } = params;
+    const { stop, embed, embedLimit, ...queryParams } = params;
+    const findOpts = stop !== undefined ? ({ scanNewestFirst: true } as const) : undefined;
     let stopped = false;
     const items: EmbeddedObject<T>[] = [];
-    const result = await this.findBy({
-      ...params,
-      limit: undefined,
-      cursor: undefined,
-    });
+    const result = await this.findBy(
+      {
+        ...queryParams,
+        limit: undefined,
+        cursor: undefined,
+      },
+      findOpts,
+    );
 
     for (let i = 0; i < result.items.length; i++) {
-      if (params.stop?.(result.items[i], i)) {
+      if (stop?.(result.items[i], i)) {
         stopped = true;
         break;
       }
@@ -359,12 +364,15 @@ export abstract class BasePersistence<T extends BaseItem> {
     }
 
     while (result.hasMore && !stopped) {
-      const nextResult = await this.findBy({
-        ...params,
-        cursor: result.cursor,
-      });
+      const nextResult = await this.findBy(
+        {
+          ...queryParams,
+          cursor: result.cursor,
+        },
+        findOpts,
+      );
       for (let i = 0; i < nextResult.items.length; i++) {
-        if (params.stop?.(nextResult.items[i], i + result.items.length)) {
+        if (stop?.(nextResult.items[i], items.length + i)) {
           stopped = true;
           break;
         }
@@ -459,11 +467,12 @@ export abstract class BasePersistence<T extends BaseItem> {
         .map((i) => i.data) ?? [];
 
     this.logger.debug({ count: items.length, hasMore: !!result.LastEvaluatedKey }, "Listed items");
+    const embeddedItems = await this.embed(items, embed, embedLimit);
     return {
-      items: await this.embed(items, embed, embedLimit),
+      items: embeddedItems,
       cursor: result.LastEvaluatedKey ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString("base64") : undefined,
       hasMore: !!result.LastEvaluatedKey,
-      count: result.Count ?? 0,
+      count: embeddedItems.length,
     };
   }
 

--- a/packages/lib/src/persistence/EmailPersistence.ts
+++ b/packages/lib/src/persistence/EmailPersistence.ts
@@ -1,5 +1,5 @@
 import { QueryCommand } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import type { Email } from "@sendra/shared";
 import { EmailSchema } from "@sendra/shared";
@@ -59,5 +59,39 @@ export class EmailPersistence extends UnembeddingBasePersistence<Email> {
       i_attr3: item.messageId,
       messageId: item.messageId, // Include messageId for GSI
     };
+  }
+
+  /**
+   * Transition `status` only if it still matches `email.status` from the read (optimistic locking).
+   * Prevents duplicate side effects when concurrent SNS handlers process the same delivery/open event.
+   */
+  async updateStatusIfUnchanged(email: Email, newStatus: Email["status"]): Promise<boolean> {
+    try {
+      const result = await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { id: email.id, type: this.type },
+          UpdateExpression: "SET #status = :newSt, #updatedAt = :now",
+          ConditionExpression: "#status = :was",
+          ExpressionAttributeNames: {
+            "#status": "status",
+            "#updatedAt": "updatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":was": email.status,
+            ":newSt": newStatus,
+            ":now": new Date().toISOString(),
+          },
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      );
+      this.trackConsumedCapacity(result);
+      return true;
+    } catch (e: unknown) {
+      if (e && typeof e === "object" && "name" in e && (e as { name: string }).name === "ConditionalCheckFailedException") {
+        return false;
+      }
+      throw e;
+    }
   }
 }

--- a/packages/subscribers/src/EmailTopicSubscriber.ts
+++ b/packages/subscribers/src/EmailTopicSubscriber.ts
@@ -106,13 +106,15 @@ async function handleEmailEvent(deliveryEvent: DeliveryEvent, email: Email, logg
         );
       }
 
-      // update status
+      // update status (conditional write avoids duplicate campaign stats when SNS delivers the same event concurrently)
       const newStatus = eventMap[deliveryEvent.eventType];
       if (newStatus !== email.status && newStatus) {
-        await new EmailPersistence(project.id).put({
-          ...email,
-          status: newStatus,
-        });
+        const emailPersistence = new EmailPersistence(project.id);
+        const applied = await emailPersistence.updateStatusIfUnchanged(email, newStatus);
+        if (!applied) {
+          metricsLogger.putMetric("EmailStatusUpdateSkipped", 1, Unit.Count);
+          return;
+        }
         metricsLogger.putMetric("EmailStatusUpdated", 1, Unit.Count);
         metricsLogger.setProperty("NewStatus", newStatus);
 


### PR DESCRIPTION
## Description

 - Fixes the logic for standard limits to not cut off incorrectly
 - adds a condition around the event handler so non-updates don't get counted multiple times
 - adds a cutoff at 100%

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] My code follows the project's style guidelines (run `npm run lint` if applicable)
- [ ] I have run `npm run build` (or equivalent) and it passes
- [ ] I have added/updated tests as needed
- [ ] I have updated documentation if needed

## Additional notes

Any additional context for reviewers.
