### PR TITLE
fix: enforce WAF on production CloudFront deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       SST_PRINT_LOGS: 1
       SST_STAGE: production
+      ENABLE_WAF: true
     needs:
       - validate
     steps:

--- a/infra/router.ts
+++ b/infra/router.ts
@@ -258,7 +258,7 @@ function handler(event) {
 
 export const router = createSingleDomainCloudFrontDistribution({
   name: "Sendra",
-  enableWaf: process.env.ENABLE_WAF === "true",
+  enableWaf: $app.stage === "production" || process.env.ENABLE_WAF === "true",
   aliases: process.env.API_URL ? [new URL(process.env.API_URL).host] : undefined,
   certificateArn: process.env.CLOUDFRONT_CERT_ARN,
 });


### PR DESCRIPTION
## What changed
- force enableWaf when stage is production in router infrastructure
- set ENABLE_WAF=true in production deploy workflow for explicit configuration

## Why
Production CloudFront updates failed with InvalidArgument about removing/replacing the web ACL for the distribution.
This ensures the production distribution always keeps a WAF ACL attached.

## Verification
- inspect generated infra diff for production stage and confirm webAclId remains set
- run production deploy workflow again