### PR TITLE
chore: fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Sendra is a fork of [Plunk](https://useplunk.com/) with a focus on a lighter foo
 
 Comprehensive documentation is available to help you get started with Sendra:
 
-- **[Deployment Guide](https://service-unit-469.github.io/Sendra/docs/setup.html)** - Step-by-step instructions for deploying Sendra to AWS
-- **[Entities Reference](https://service-unit-469.github.io/Sendra/docs/entities.html)** - Understanding Sendra's data model and key entities
-- **[API Documentation](https://service-unit-469.github.io/Sendra/docs/api.html)** - Complete guide to the Sendra API with examples
-- **[User Guide](https://service-unit-469.github.io/Sendra/docs/user-guide.html)** - How to use the Sendra application
+- **[Deployment Guide](https://service-unit-469.github.io/Sendra/setup.html)** - Step-by-step instructions for deploying Sendra to AWS
+- **[Entities Reference](https://service-unit-469.github.io/Sendra/entities.html)** - Understanding Sendra's data model and key entities
+- **[API Documentation](https://service-unit-469.github.io/Sendra/api.html)** - Complete guide to the Sendra API with examples
+- **[User Guide](https://service-unit-469.github.io/Sendra/user-guide.html)** - How to use the Sendra application
 
 ## Self-hosting Sendra
 
@@ -42,10 +42,10 @@ The easiest way to self-host Sendra is to fork the project and run it in your AW
 
 1. **Prerequisites**: Node.js 20+, AWS CLI configured, AWS account
 2. **Install**: `pnpm install`
-3. **Configure**: Set up environment variables (see [deployment guide](https://service-unit-469.github.io/Sendra/docs/setup.html))
+3. **Configure**: Set up environment variables (see [deployment guide](https://service-unit-469.github.io/Sendra/setup.html))
 4. **Deploy**: `pnpm run deploy`
 
-A complete guide on how to deploy Sendra can be found in the [deployment documentation](https://service-unit-469.github.io/Sendra/docs/setup.html).
+A complete guide on how to deploy Sendra can be found in the [deployment documentation](https://service-unit-469.github.io/Sendra/setup.html).
 
 ## Contributing
 


### PR DESCRIPTION
Updated links in the README for deployment, entities, API documentation, and user guide to remove '/docs/' from URLs.

## Description

Brief description of the changes in this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] My code follows the project's style guidelines (run `npm run lint` if applicable)
- [ ] I have run `npm run build` (or equivalent) and it passes
- [ ] I have added/updated tests as needed
- [ ] I have updated documentation if needed

## Additional notes

Any additional context for reviewers.
